### PR TITLE
Add dataset stats display

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
         </div>
       </div>
 
+      <div id="stats" class="stats"></div>
       <section id="grants" class="grants"></section>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -144,6 +144,12 @@ function createGrantCard(grant) {
   return card;
 }
 
+function showStats() {
+  const el = document.getElementById('stats');
+  if (!el) return;
+  el.textContent = `${researcherNames.length} researchers • ${grantsData.length} grants`;
+}
+
 function showGrants(name) {
   const grantsContainer = document.getElementById('grants');
   grantsContainer.innerHTML = '';
@@ -164,6 +170,8 @@ function showGrants(name) {
 
 async function init() {
   await loadData();
+
+  showStats();
 
   showLandingWizard();
 

--- a/styles.css
+++ b/styles.css
@@ -143,6 +143,14 @@ main {
 .suggestion-item:hover,
 .suggestion-item:focus  { background: var(--accent); color: #ffffff; }
 
+/* ========== Dataset stats ========== */
+.stats {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
 /* ========== Grant cards ========== */
 .grants {
   display: grid;


### PR DESCRIPTION
## Summary
- add a stats element in the HTML layout
- style new stats section
- calculate and display counts for researchers and grants on page load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873e3763d60832e91785da7dd06a1a0