### PR TITLE
Fix chart size on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
         </div>
       </div>
       <div class="chart-grid">
-        <canvas id="providerChart" width="320" height="320" aria-label="Grants by provider" role="img"></canvas>
-        <canvas id="deadlineChart" width="320" height="320" aria-label="Upcoming deadlines" role="img"></canvas>
+        <canvas id="providerChart" aria-label="Grants by provider" role="img"></canvas>
+        <canvas id="deadlineChart" aria-label="Upcoming deadlines" role="img"></canvas>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -211,7 +211,8 @@ function showDashboard() {
     },
     options: {
       plugins: { legend: { display: false } },
-      animation: { duration: 800 }
+      animation: { duration: 800 },
+      aspectRatio: 1
     }
   });
 
@@ -248,7 +249,8 @@ function showDashboard() {
         y: { beginAtZero: true, ticks: { precision: 0 }, grid: { color: '#eeeeee' } },
         x: { grid: { display: false } }
       },
-      animation: { duration: 800 }
+      animation: { duration: 800 },
+      aspectRatio: 1
     }
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -196,7 +196,7 @@ main {
   padding: 1rem;
   box-shadow: 0 4px 10px rgba(0,0,0,0.08);
   width: 100%;
-  max-width: 280px;
+  max-width: 400px;
   height: auto;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,9 @@ main {
   border-radius: 12px;
   padding: 1rem;
   box-shadow: 0 4px 10px rgba(0,0,0,0.08);
+  width: 100%;
+  max-width: 280px;
+  height: auto;
 }
 
 .stat {


### PR DESCRIPTION
## Summary
- make dashboard charts responsive
- set chart aspect ratio to 1:1
- remove fixed canvas dimensions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6873f9b957b0832ea003f1a37b9a1a21