### PR TITLE
Add Google Analytics event tracking

### DIFF
--- a/script.js
+++ b/script.js
@@ -427,6 +427,11 @@ async function init() {
   document.getElementById('tab-grants-btn').addEventListener('click', () => showTab('grants'));
   document.getElementById('tab-stats').addEventListener('click', () => showTab('stats'));
 
+  const linkedInLink = document.querySelector('footer .linkedin');
+  if (linkedInLink) {
+    linkedInLink.addEventListener('click', () => track('click_linkedin'));
+  }
+
   const input = document.getElementById('researcher-input');
   input.addEventListener('input', (e) => updateSuggestions(e.target.value));
   input.addEventListener('focus', (e) => updateSuggestions(e.target.value));

--- a/teaser.js
+++ b/teaser.js
@@ -15,7 +15,11 @@ function showTeaser() {
     <button class="teaser-cta">Engage the Robot \ud83e\udd16</button>
   `;
   document.getElementById('grants').appendChild(card);
-  card.querySelector('button').addEventListener('click', openModal);
+  const teaserBtn = card.querySelector('button');
+  teaserBtn.addEventListener('click', openModal);
+  teaserBtn.addEventListener('click', () =>
+    track('click_teaser_cta', { researcher_name: selectedName })
+  );
 }
 
 function openModal() {


### PR DESCRIPTION
## Summary
- add `track()` helper for GA4 events
- instrument tab switches, researcher selection, and grant card actions
- record grant table exports and searches
- log teaser CTA clicks

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_687c5b617dd0832e84f4151172c84c3e