### PR TITLE
Add gitignore for PyCharm and Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# General
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Virtual environments
+env/
+venv/
+ENV/
+.venv/
+
+# PyCharm IDE directories
+.idea/
+.idea*/
+.ideas/
+.ideas*/
+


### PR DESCRIPTION
## Summary
- add a `.gitignore` to keep PyCharm and Python artifacts out of version control

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c79f672dc832e969fde48a5b1e485